### PR TITLE
Fix missing link issues in site generation

### DIFF
--- a/ical-tasks/sources/draft-ietf-calext-ical-tasks.adoc
+++ b/ical-tasks/sources/draft-ietf-calext-ical-tasks.adoc
@@ -32,7 +32,7 @@
 :contibutor-uri_2: https://bcs.com/
 :email_2: mdouglass@bedework.com
 :mn-document-class: ietf
-:mn-output-extensions: xml,txt,html
+:mn-output-extensions: xml,txt,html,rxl
 :technical-committee: TC Calendar
 
 include::sections/00-abstract.adoc[]


### PR DESCRIPTION
The `metanorma` requires us to have `rxl` as an extension for some standards, and if missing then it can't generate the collection in proper way. This was one the issue for missing link. This commit should fix the issue and it should link the internal documents properly.

One thing to note, there is still one issue with how it handles the `RFC`, but that is something we will address soon.

Related: https://github.com/metanorma/metanorma-cli/issues/297

//cc: @ronaldtse 