### PR TITLE
Add a sample UML diagram and model descriptions to ical-tasks

### DIFF
--- a/ical-tasks/sources/cc-11001.adoc
+++ b/ical-tasks/sources/cc-11001.adoc
@@ -69,6 +69,7 @@ include::sections/54-new-components.adoc[]
 
 include::sections/60-caldav.adoc[]
 
+include::sections/70-model.adoc[]
 
 include::sections/100-security.adoc[]
 

--- a/ical-tasks/sources/model/calendar.lutaml
+++ b/ical-tasks/sources/model/calendar.lutaml
@@ -1,0 +1,20 @@
+class Calendar {
+  definition {
+    A calendar.
+  }
+
+  identifier: String[1] {
+    definition {
+      Unique identifier of the calendar.
+
+      [example]
+      `calendar:1234` is a sample of a unique calendar identifier.
+    }
+  }
+
+  events: Event[0..*] {
+    definition {
+      Events.
+    }
+  }
+}

--- a/ical-tasks/sources/model/event.lutaml
+++ b/ical-tasks/sources/model/event.lutaml
@@ -1,0 +1,39 @@
+class Event {
+  definition {
+    An event.
+  }
+
+  identifier: String[1] {
+    definition {
+      Unique identifier of the event.
+
+      [example]
+      `event:1234` is a sample of a unique event identifier.
+    }
+  }
+
+  startTime: DateTime[1] {
+    definition {
+      Start time of the event.
+    }
+  }
+
+  endTime: DateTime[1] {
+    definition {
+      End time of the event.
+    }
+  }
+
+  location: String[1] {
+    definition {
+      Location of the event.
+    }
+  }
+
+  description: String[1] {
+    definition {
+      Description of the event.
+    }
+  }
+
+}

--- a/ical-tasks/sources/sections/70-model.adoc
+++ b/ical-tasks/sources/sections/70-model.adoc
@@ -1,0 +1,23 @@
+
+== Model
+
+=== General
+
+lutaml_diagram::views/calendar_view.lutaml[]
+
+
+// Calendar
+
+[lutaml_uml_class,views/calendar_view.lutaml,Calendar]
+
+// Event
+
+[lutaml_uml_class,views/calendar_view.lutaml,Event]
+
+
+== Class attribute tables
+
+[lutaml_uml_attributes_table,views/calendar_view.lutaml,Calendar]
+
+[lutaml_uml_attributes_table,views/calendar_view.lutaml,Event]
+

--- a/ical-tasks/sources/views/calendar_view.lutaml
+++ b/ical-tasks/sources/views/calendar_view.lutaml
@@ -1,0 +1,13 @@
+diagram CalendarView {
+  title 'Calendar and its models'
+  caption 'Calendar and its models'
+
+  include ../model/calendar.lutaml
+  include ../model/event.lutaml
+
+  association {
+    owner Calendar
+    member Event
+    owner_type association
+  }
+}


### PR DESCRIPTION
For @douglm .

This PR adds the following to the iCal-Tasks document:
* A UML diagram
* Two UML classes, a "Calendar" and an "Event". It would be easy to rename them into "VCalendar" and "VTodo" and add the appropriate attributes, etc.

The UML syntax used is called LutaML:
* https://github.com/lutaml/lutaml-uml/blob/main/LUTAML.adoc

## Structure

The diagram is stored at:
* ical-tasks/sources/views/calendar_view.lutaml

The class definitions are at:
* ical-tasks/sources/model/calendar.lutaml
* ical-tasks/sources/model/event.lutaml

The LutaML structure works like this:
* A diagram is needed to wrap any classes
* A diagram can include many classes
* A class can be "associated" with another class via UML relationships such as "generalization", "association", etc (see syntax)

## Rendering in text

In the new file `sections/70-model.adoc`, it looks like this:

```adoc
== Model
=== General

lutaml_diagram::views/calendar_view.lutaml[]

// Calendar
[lutaml_uml_class,views/calendar_view.lutaml,Calendar]

// Event
[lutaml_uml_class,views/calendar_view.lutaml,Event]

== Class attribute tables

[lutaml_uml_attributes_table,views/calendar_view.lutaml,Calendar]

[lutaml_uml_attributes_table,views/calendar_view.lutaml,Event]
```

### lutaml_diagram

This line: `lutaml_diagram::views/calendar_view.lutaml[]`

Makes Metanorma render the diagram.


### lutaml_uml_class

This line: `[lutaml_uml_class,views/calendar_view.lutaml,Calendar]`

Makes Metanorma render a clause that contains the descriptions and definitions of the UML class "Calendar" class.


### lutaml_uml_attributes_table

This line: `[lutaml_uml_attributes_table,views/calendar_view.lutaml,Calendar]`

Makes Metanorma render a table of UML attributes for the "Calendar" class in the calendar_view.lutaml view.

## That's it

Hope this helps!